### PR TITLE
Add dark color scheme to GH buttons

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -64,8 +64,8 @@ class Header extends Component {
   renderGithubButtons() {
     if (this.props.query.title !== 'About Dracula') {
       return <p className="gh-buttons">
-        <GitHubButton href="https://github.com/dracula/dracula-theme" data-size="large" data-show-count="true" aria-label="Star dracula/dracula-theme on GitHub">Star</GitHubButton>
-        <GitHubButton href="https://github.com/dracula/dracula-theme/fork" data-size="large" data-show-count="true" aria-label="Fork dracula/dracula-theme on GitHub">Fork</GitHubButton>
+        <GitHubButton href="https://github.com/dracula/dracula-theme" data-color-scheme="dark" data-size="large" data-show-count="true" aria-label="Star dracula/dracula-theme on GitHub">Star</GitHubButton>
+        <GitHubButton href="https://github.com/dracula/dracula-theme/fork" data-color-scheme="dark" data-size="large" data-show-count="true" aria-label="Fork dracula/dracula-theme on GitHub">Fork</GitHubButton>
       </p>
     }
   }


### PR DESCRIPTION
If implemented, this pull request changes the bright white "star" and "fork" buttons to dark gray, matching the darkness of the rest of the webpage.

Note: You could also replace the octocat icons on each button with star and fork icons by adding the attributes `data-icon="octicon-star"` and `data-icon="octicon-repo-forked"` to the star and fork buttons respectively. However, I didn't want to change more than just the darkness in case it wasn't wanted. If you have write access you can edit this patch anyways.