### PR TITLE
:ambulance: Fix Gumroad cart overlay

### DIFF
--- a/components/pro/Pricing.js
+++ b/components/pro/Pricing.js
@@ -204,8 +204,7 @@ class Pricing extends Component {
               <div className={styles.buy}>
                 <a
                   href={gumroadURL}
-                  className="gumroad-button"
-                  className={styles.cta}
+                  className={`${styles.cta} gumroad-button`}
                 >
                   Buy Dracula PRO
                 </a>

--- a/components/pro/Topbar.js
+++ b/components/pro/Topbar.js
@@ -1,19 +1,25 @@
-import { Component } from 'react';
-import Link from 'next/link';
-import Countdown from '../Countdown';
-import styles from './Topbar.module.css';
+import { Component } from 'react'
+import Countdown from '../Countdown'
+import Link from 'next/link'
+import styles from './Topbar.module.css'
 
 class Topbar extends Component {
   render() {
-    return <div className={styles.fixed}>
-      <Countdown ppp={this.props.ppp} color="#8aff80" />
-      <nav className={styles.topbar}>
-        <Link href="/">
-          <a className="topbar-title">Dracula <span className={styles.titlePro}>PRO</span></a>
-        </Link>
-        <a href="/pro#get" className={styles.cta}>Get it now</a>
-      </nav>
-    </div>
+    return (
+      <div className={styles.fixed}>
+        <nav className={styles.topbar}>
+          <Link href="/">
+            <a className="topbar-title">
+              Dracula <span className={styles.titlePro}>PRO</span>
+            </a>
+          </Link>
+          <a href="/pro#get" className={styles.cta}>
+            Get it now
+          </a>
+        </nav>
+        <Countdown ppp={this.props.ppp} color="#8aff80" />
+      </div>
+    )
   }
 }
 

--- a/components/pro/Topbar.module.css
+++ b/components/pro/Topbar.module.css
@@ -27,7 +27,7 @@
 
 .cta {
   transition: all 0.3s ease-in-out;
-  margin-right: 20px;
+  margin-right: 90px;
   display: inline-block;
   background: #50fa7b;
   text-align: center;

--- a/components/shop/Topbar.js
+++ b/components/shop/Topbar.js
@@ -31,9 +31,6 @@ class Topbar extends Component {
                 <a>Other</a>
               </Link>
             </li>
-            <li className={styles.cart}>
-              <i className={styles.cartIcon} />
-            </li>
           </ul>
         </nav>
       </div>

--- a/components/shop/Topbar.module.css
+++ b/components/shop/Topbar.module.css
@@ -17,6 +17,10 @@
   z-index: 1;
 }
 
+.topbar ul {
+  margin: 20px 90px 20px 0;
+}
+
 .title {
   display: flex;
 }

--- a/pages/pro/index.js
+++ b/pages/pro/index.js
@@ -1,23 +1,22 @@
-import React from 'react'
-import Head from 'next/head'
-import queryString from 'query-string'
 import Airtable from 'airtable'
-
-import { getBasePath } from '../../lib/environment'
-import Topbar from '../../components/pro/Topbar'
-import Discount from '../../components/pro/Discount'
-import Header from '../../components/pro/Header'
 import Description from '../../components/pro/Description'
-import Preview from '../../components/pro/Preview'
-import Why from '../../components/pro/Why'
-import Palette from '../../components/pro/Palette'
+import Discount from '../../components/pro/Discount'
+import Ebook from '../../components/pro/Ebook'
 import Features from '../../components/pro/Features'
 import Fonts from '../../components/pro/Fonts'
-import Ebook from '../../components/pro/Ebook'
-import Testimonial from '../../components/pro/Testimonial'
-import Pricing from '../../components/pro/Pricing'
-import Reviews from '../../components/pro/Reviews'
 import Footer from '../../components/pro/Footer'
+import Head from 'next/head'
+import Header from '../../components/pro/Header'
+import Palette from '../../components/pro/Palette'
+import Preview from '../../components/pro/Preview'
+import Pricing from '../../components/pro/Pricing'
+import React from 'react'
+import Reviews from '../../components/pro/Reviews'
+import Testimonial from '../../components/pro/Testimonial'
+import Topbar from '../../components/pro/Topbar'
+import Why from '../../components/pro/Why'
+import { getBasePath } from '../../lib/environment'
+import queryString from 'query-string'
 
 export async function getStaticProps() {
   try {
@@ -64,7 +63,10 @@ class Pro extends React.Component {
     this.setState({ queryParams })
     this.fetchPPP()
 
-    document.documentElement.style.setProperty('--cart-visibility', 'block')
+    document.documentElement.style.setProperty(
+      '--cart-visibility',
+      'inline-flex'
+    )
   }
 
   componentWillUnmount() {
@@ -121,10 +123,7 @@ class Pro extends React.Component {
         </Head>
 
         <Topbar ppp={this.state.ppp} />
-        <Discount
-          ppp={this.state.ppp}
-          queryParams={this.state.queryParams}
-        />
+        <Discount ppp={this.state.ppp} queryParams={this.state.queryParams} />
         <Header
           title={title}
           description={description}

--- a/pages/shop/index.js
+++ b/pages/shop/index.js
@@ -1,10 +1,10 @@
-import React from 'react'
 import Head from 'next/head'
-import Link from 'next/link'
-import ShopLayout from '../../layouts/Shop'
 import Hero from '../../components/shop/Hero'
-import products from '../../lib/shop'
+import Link from 'next/link'
+import React from 'react'
+import ShopLayout from '../../layouts/Shop'
 import { getProduct } from '../../lib/gumroad'
+import products from '../../lib/shop'
 
 export async function getStaticProps() {
   const productPromises = products.map(product => {
@@ -17,7 +17,10 @@ export async function getStaticProps() {
 
 class Shop extends React.Component {
   componentDidMount() {
-    document.documentElement.style.setProperty('--cart-visibility', 'block')
+    document.documentElement.style.setProperty(
+      '--cart-visibility',
+      'inline-flex'
+    )
   }
 
   componentWillUnmount() {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1765,6 +1765,19 @@ a {
   --cart-visibility: none;
 }
 
-body .gumroad-scroll-container {
+.gumroad .cart-button {
   display: var(--cart-visibility);
+  position: fixed;
+  top: 0.5rem;
+  right: 1rem;
+  gap: 0.5rem;
+  border: none;
+  color: rgb(var(--rgbForeground));
+  background: none;
+}
+
+.gumroad .cart-button:hover {
+  transform: none !important;
+  color: rgb(var(--rgbPurple));
+  box-shadow: none !important;
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1781,3 +1781,8 @@ a {
   color: rgb(var(--rgbPurple));
   box-shadow: none !important;
 }
+
+.gumroad-button .logo-full,
+.gumroad .logo-full {
+  display: none;
+}


### PR DESCRIPTION
I removed the static Gumroad cart on the shop page and just centred the Gumroad widget in the same place. 📌

![image](https://user-images.githubusercontent.com/48334856/195377852-9fd8f00c-3840-4de8-a9b4-a9172aab45c4.png)

The same will not appear on Dracula's homepage, only on the Shop and Pro pages.

On the Pro page, it was necessary to invert the order of the countdown banner so as not to break the layout.

![image](https://user-images.githubusercontent.com/48334856/195378015-d24697ef-8cbe-4c79-88b5-c01baac5a3b5.png)

The cart is only visible if products exist; Gumroad handles this 😥