### PR TITLE
Add tig to paths.js

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -276,6 +276,7 @@ const paths = [
   { params: { theme: "thonny", title: "Thonny", repo: "thonny", color: "orange", icon: "used/pack-4/042-hydra.svg", platform: ["all"] } },
   { params: { theme: "thunderbird", title: "Thunderbird", repo: "thunderbird", color: "purple", icon: "used/pack-4/003-phoenix.svg", platform: ["all"] } },
   { params: { theme: "tiddlywiki", title: "TiddlyWiki", repo: "tiddlywiki", color: "purple", icon: "used/pack-5/035-tent.svg", platform: ["all"] } },
+  { params: { theme: 'tig', title: 'tig', repo: 'tig', color: 'green', icon: 'used/pack-10/011-cauldron.svg', platform: ['all'] } },
   { params: { theme: "tilix", title: "Tilix", repo: "tilix", color: "cyan", icon: "used/pack-2/046-ghost.svg", platform: ["linux"] } },
   { params: { theme: "tint2", title: "tint2", repo: "tint2", color: "cyan", icon: "used/pack-5/009-potion.svg", platform: ["linux"] } },
   { params: { theme: "tmux", title: "tmux", repo: "tmux", color: "purple", icon: "used/pack-1/030-clown.svg", platform: ["linux", "mac"] } },


### PR DESCRIPTION
Hi.

I have fixed the missing `tig` settings.
Perhaps it disappeared due to conflict resolution.

`Add tig by @aftaylor2`
https://github.com/dracula/draculatheme.com/commit/bbdd7a4eedf9031c98a3c61332095fc4518cc311

`🚚 Resolve conflicts`
https://github.com/dracula/draculatheme.com/commit/72ff44f151afb09b5d9e1360e0e8b5d6b6245ce7