### PR TITLE
Fix readme and copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 5. And finally run:
 
    ```sh
-   $ npm dev
+   $ npm run dev
    ```
 
 Now you should see the website running in `localhost:3000` 😁

--- a/src/components/markdown/codeCopyBtn/index.scss
+++ b/src/components/markdown/codeCopyBtn/index.scss
@@ -5,6 +5,7 @@
   right: 1rem;
   border: none;
   cursor: pointer;
+  z-index: 1;
 
   * {
     outline: none !important;


### PR DESCRIPTION
- The Read me tells to run `npm dev` instead of `npm run dev` &
- The copy to the clipboard button was behind the _codeblock_ component, `z-index: 1;` fixes it.